### PR TITLE
Change require to 'redis'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Install
 ```
-$ shards install
+$ shards install or crystal deps
 $ crystal build razor.cr --release (without CNAME support | A --> random IP)
 $ crystal build razor.cr --release -Dcname (with CNAME support | CNAME --> A --> random IP)
 ```

--- a/razor.cr
+++ b/razor.cr
@@ -1,4 +1,4 @@
-require "./libs/crystal-redis/redis"
+require "redis"
 
 class Razor
 

--- a/shard.yml
+++ b/shard.yml
@@ -2,7 +2,7 @@ name: pdns_razor
 version: 0.1.0
 
 dependencies:
-  crystal-redis:
+  redis:
     git: https://github.com/stefanwille/crystal-redis.git
     version: ~> 1.2.0
 


### PR DESCRIPTION
Change require to 'redis'. Fixed by https://github.com/stefanwille/crystal-redis/pull/9
