### PR TITLE
Return NS records as part of query

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: pdns_razor
-version: 0.1.1
+version: 0.1.2
 
 dependencies:
   redis:


### PR DESCRIPTION
Return NS records as part of query.

```
% dig delfi.lt @192.168.168.128 NS +short
dns1.000webhost.com.
dns2.000webhost.com.

% dig a.delfi.lt @192.168.168.128 A +short
2.2.2.2
```

@tonyspa @fordnox
