### PR TITLE
Add additional metadata for zone to return (e.g. dynamic TTL)

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: pdns_razor
-version: 0.1.2
+version: 0.1.3
 
 dependencies:
   redis:


### PR DESCRIPTION
Add additional metadata for zone to return (e.g. dynamic TTL).

```
127.0.0.1:6379> hgetall us-east-1.route-1.000webhost.awex.io
1) "TTL"
2) "12"

% dig +nocmd +noall +answer delfi.lt @192.168.168.128
delfi.lt.       12  IN  A   2.2.2.2
```

@tonyspa @fordnox
