### PR TITLE
Respond DNS query only if Redis has a key

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: pdns_razor
-version: 0.1.3
+version: 0.1.4
 
 dependencies:
   redis:


### PR DESCRIPTION
Respond DNS query only if Redis has a key.

```
% dig us-east-1.route-1.000webhost.awex.io @192.168.168.128 NS +short
dns2.000webhost.com.
dns1.000webhost.com.

% dig us-east-1.route-1.000webhost.awex.io @192.168.168.128 SOA +short
us-east-1.route-1.000webhost.awex.io. hostmaster.us-east-1.route-1.000webhost.awex.io. 2016102706 600 600 604800 600

% dig delfi.lt @192.168.168.128 SOA +short
<empty>

% dig delfi.lt @192.168.168.128 NS +short
<empty>
```

@fordnox @tonyspa
