### PR TITLE
Convert qname to lowercase to avoid `REFUSED` responses

### DIFF
--- a/razor.cr
+++ b/razor.cr
@@ -19,7 +19,8 @@ class Razor
 
   def mainLoop
     loop do
-      name, qtype = parseQuery STDIN.read_line
+      qname, qtype = parseQuery STDIN.read_line
+      name = qname.downcase
       ttl = getTTL(name)
 
       case qtype

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: pdns_razor
-version: 0.1.7
+version: 0.1.8
 
 dependencies:
   redis:


### PR DESCRIPTION
Convert qname to lowercase to avoid `REFUSED` responses. Related: https://github.com/PowerDNS/pdns/issues/5088